### PR TITLE
Adding an Env file for Secret key

### DIFF
--- a/Universidad/settings.py
+++ b/Universidad/settings.py
@@ -33,7 +33,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-87yxnd2=w=%@=p1!vc*(e^4_l!)fbs#)$1h2#q%5x5$39g#y60'
+SECRET_KEY = env(SECRET_KEY)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Te recomiendo que ignores el .env desde el .gitignore es una mala practica tener direcciones - URLS - Keys y demás cosas que puedan afectar la seguridad de tu software,  solo hice un ejemplo pero puedes usar el .env del os ya que puede ser un poco más seguro debido a que este es manejado por el os.

el ejemplo que realize fue con tu entorno de env() aunque podrías checar esto: https://www.npmjs.com/package/dotenv cuando trabajes con servidor.